### PR TITLE
Fix post request example naming and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,24 @@ cable is capable of generating.
 }
 
 {
+  "name": "post request",
+  "type": "request",
+  "id": 2,
+  "binary": "6b020000000004baaffb010315ed54965515babf6f16be3f96b04b29ecca813a343311dae483691c07ccf4e597fc63631c41384226b9b68d9f73ffaaf6eac54b71838687f48f112e30d6db689c2939fec6d47b00bafe6967aeff697cf4b5abca01b04ba1b31a7e3752454bfa",
+  "obj": {
+    "msgLen": 107,
+    "msgType": 2,
+    "reqid": "04baaffb",
+    "ttl": 1,
+    "hashes": [
+      "15ed54965515babf6f16be3f96b04b29ecca813a343311dae483691c07ccf4e5",
+      "97fc63631c41384226b9b68d9f73ffaaf6eac54b71838687f48f112e30d6db68",
+      "9c2939fec6d47b00bafe6967aeff697cf4b5abca01b04ba1b31a7e3752454bfa"
+    ]
+  }
+}
+
+{
   "name": "cancel request",
   "type": "request",
   "id": 3,
@@ -260,24 +278,6 @@ cable is capable of generating.
       "default",
       "dev",
       "introduction"
-    ]
-  }
-}
-
-{
-  "name": "hash response",
-  "type": "response",
-  "id": 2,
-  "binary": "6b020000000004baaffb010315ed54965515babf6f16be3f96b04b29ecca813a343311dae483691c07ccf4e597fc63631c41384226b9b68d9f73ffaaf6eac54b71838687f48f112e30d6db689c2939fec6d47b00bafe6967aeff697cf4b5abca01b04ba1b31a7e3752454bfa",
-  "obj": {
-    "msgLen": 107,
-    "msgType": 2,
-    "reqid": "04baaffb",
-    "ttl": 1,
-    "hashes": [
-      "15ed54965515babf6f16be3f96b04b29ecca813a343311dae483691c07ccf4e5",
-      "97fc63631c41384226b9b68d9f73ffaaf6eac54b71838687f48f112e30d6db68",
-      "9c2939fec6d47b00bafe6967aeff697cf4b5abca01b04ba1b31a7e3752454bfa"
     ]
   }
 }

--- a/example.js
+++ b/example.js
@@ -37,6 +37,12 @@ const keypair = crypto.generateKeypair()
 const link = crypto.hash(b4a.from("not a message payload at all actually"))
 const ttl = 1
 
+// 2: post request
+const bufHashReq = POST_REQUEST.create(crypto.generateReqID(), 3, hashes)
+console.log("msg type of post request", cable.peekMessage(bufHashReq))
+const objHashReq = POST_REQUEST.toJSON(bufHashReq)
+console.log(objHashReq)
+
 // 3: cancel request
 const cancelId = crypto.generateReqID()
 const b = CANCEL_REQUEST.create(crypto.generateReqID(), ttl, cancelId)
@@ -85,12 +91,6 @@ console.log(bufListRes)
 console.log("msg type of channel list response", cable.peekMessage(bufListRes))
 const objListRes = CHANNEL_LIST_RESPONSE.toJSON(bufListRes)
 console.log(objListRes)
-
-// 2: hash response
-const bufHashReq = POST_REQUEST.create(crypto.generateReqID(), 3, hashes)
-console.log("msg type of post request", cable.peekMessage(bufHashReq))
-const objHashReq = POST_REQUEST.toJSON(bufHashReq)
-console.log(objHashReq)
 
 
 /* post types */


### PR DESCRIPTION
While adding tests to `cable.rs` I noticed that the post request example had been incorrectly named as hash response.

This PR fixes `example.js` and the output listed in the `README`. I think it's correct now but please double-check 🙏🏻  